### PR TITLE
"keyCode" replaced with "key" property

### DIFF
--- a/client/script.js
+++ b/client/script.js
@@ -114,7 +114,7 @@ const handleSubmit = async (e) => {
 
 form.addEventListener('submit', handleSubmit)
 form.addEventListener('keyup', (e) => {
-    if (e.keyCode === 13) {
+    if (e.key === "Enter") {
         handleSubmit(e)
     }
 })


### PR DESCRIPTION
The keyCode property in JavaScript was deprecated due to its limitations, inconsistencies, and lack of readability. The key property has replaced it and provides a more reliable, understandable, and self-explanatory way of identifying keys that were pressed.